### PR TITLE
Fix: Support Chunk from Stdin entry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,16 +142,15 @@ const filePath = process.argv[3];
 process.stdin.setEncoding("utf8");
 
 
-//Support chunked input
-
+// Support chunked input
 let inputData = "";
 
 // Read data from stdin
-process.stdin.on('data', chunk => {
+process.stdin.on("data", chunk => {
   inputData += chunk;
 })
 
 // Read data from stdin
-process.stdin.on('end', () => {
+process.stdin.on("end", () => {
   processInput(folderPath, filePath, inputData);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,17 @@ const filePath = process.argv[3];
 // Set encoding for stdin
 process.stdin.setEncoding("utf8");
 
+
+//Support chunked input
+
+let inputData = "";
+
 // Read data from stdin
-process.stdin.on("data", (data) => {
-  processInput(folderPath, filePath, data);
+process.stdin.on('data', chunk => {
+  inputData += chunk;
+})
+
+// Read data from stdin
+process.stdin.on('end', () => {
+  processInput(folderPath, filePath, inputData);
 });


### PR DESCRIPTION
🚀 Added Chunk Support to `stdin` Input Handling 🛠️

### Description:
Hello there! 👋

I've been using your awesome `audit-export` package and it's been super helpful! Recently, I encountered an issue when dealing with large JSON from `npm audit --json`. The data was getting truncated due to `process.stdin` buffer limitations.

To tackle this, I've made some modifications to the stdin input handling to support data chunks. 🧩

**What's Changed:**
- The `process.stdin.on('data', ...)` now accumulates data in chunks.
- Once the 'end' event is triggered, the complete data set is processed. 🔄
- This ensures that even large JSON's are read and processed correctly. 📚

I've tested these changes in various scenarios, and they seem to work perfectly, ensuring that `audit-export` can handle larger datasets without any hiccups. 🎉

I believe this enhancement would be beneficial for others facing similar issues with large `npm audit` JSON outputs. I'd love for you to take a look and consider merging it into the main branch. 🌟

Thank you for your fantastic work on this package, and I'm looking forward to potentially contributing more in the future! 😊

Best regards,
Camilo Bernal 
