### PR TITLE
Added command line parser + title customization support

### DIFF
--- a/src/template.ejs
+++ b/src/template.ejs
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NPM Audit Report</title>
+  <title><%= npmReportTitle %></title>
   <style>
     * {
       margin: 0;
@@ -142,7 +142,7 @@
 
 <body>
 
-  <h1>NPM Audit Report</h1>
+  <h1><%= npmReportTitle %></h1>
 
   <div class="info-categories">
     <div class="info-block">


### PR DESCRIPTION
This PR adds a simple (and standalone) argument parser to help the use of more "advanced" options.

I included a title option to replace the report title.

## Pre-launch Checklist

- [x] I read the [Contribution Guide](https://github.com/hotaydev/audit-export/blob/main/.github/CONTRIBUTING.md) and followed the process for submitting PRs.
- [ ] I listed at least one issue this PR fixes in the description above.
- [x] I have tested this package in at least two versions of Node.js (one lower than the v14 and one higher than the v16)
I tested the code on node v18 / v20. The changes should be compatible with any lower Node release.
